### PR TITLE
Update adversarial-training-mnist-WS.ipynb to not use COS

### DIFF
--- a/notebooks/adversarial-training-mnist-WS.ipynb
+++ b/notebooks/adversarial-training-mnist-WS.ipynb
@@ -82,48 +82,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Training this model can take a long time, so for this example we just load a previously trained model from its saved state. On Watson Studio we upload the saved model onto Cloud Object Storage, need to provide credentials for it. Then we will load the classifier model."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cos_creds = {\n",
-    "      \"apikey\": \"\",\n",
-    "  \"cos_hmac_keys\": {\n",
-    "    \"access_key_id\": \"\",\n",
-    "    \"secret_access_key\": \"\"\n",
-    "  },\n",
-    "  \"endpoints\": \"https://control.cloud-object-storage.cloud.ibm.com/v2/endpoints\",\n",
-    "  \"iam_apikey_description\": \"Auto generated apikey ...\",\n",
-    "  \"iam_apikey_name\": \"auto-generated-apikey-...\",\n",
-    "  \"iam_role_crn\": \"crn:v1:bluemix:public:iam::::serviceRole:Writer\",\n",
-    "  \"iam_serviceid_crn\": \"crn:v1:bluemix:public:iam-identity::...\",\n",
-    "  \"resource_instance_id\": \"crn:v1:bluemix:public:cloud-object-storage:global:...::\"\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Insert your COS credential above and the names of the buckets below. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cos_info={\n",
-    "    'endpoint': 'https://s3.us.cloud-object-storage.appdomain.cloud',\n",
-    "    'data_bucket': '',\n",
-    "    'result_bucket':''\n",
-    "}"
+    "Training this model can take a long time, so for this example we just load a previously trained model from its saved state. On Watson Studio we download the saved model onto the current Python kernel. Then we will load the classifier model."
    ]
   },
   {
@@ -142,29 +101,17 @@
    "outputs": [],
    "source": [
     "import requests\n",
-    "from ibm_botocore.client import Config\n",
-    "import ibm_boto3\n",
-    "cos = ibm_boto3.resource('s3',\n",
-    "    ibm_api_key_id=cos_creds['apikey'],\n",
-    "    ibm_service_instance_id=cos_creds['resource_instance_id'],\n",
-    "    ibm_auth_endpoint='https://iam.bluemix.net/oidc/token',\n",
-    "    config=Config(signature_version='oauth'),\n",
-    "    endpoint_url=cos_info['endpoint'])\n",
     "\n",
     "def download_files(link, name):\n",
     "    response = requests.get(link)\n",
     "    open(name, 'wb').write(response.content)\n",
-    "    \n",
-    "def upload_files_to_bucket(link, name):\n",
-    "    download_files(link, name)\n",
-    "    cos.Bucket(cos_info['data_bucket']).upload_file(name, name)\n",
-    "    print('done uploading ' + name)\n",
+    "\n",
     "\n",
     "orig_model_link = 'https://github.com/IBM/ML-Pipelines-101/raw/master/models/mnist_cnn_original.h5'\n",
     "robust_model_link = 'https://github.com/IBM/ML-Pipelines-101/raw/master/models/mnist_cnn_robust.h5'\n",
     "\n",
-    "upload_files_to_bucket(orig_model_link, 'mnist_cnn_original.h5')\n",
-    "upload_files_to_bucket(robust_model_link, 'mnist_cnn_robust.h5')\n"
+    "download_files(orig_model_link, 'mnist_cnn_original.h5')\n",
+    "download_files(robust_model_link, 'mnist_cnn_robust.h5')\n"
    ]
   },
   {
@@ -434,18 +381,11 @@
     "plt.ylabel('Correct predictions')\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.6",
    "language": "python",
    "name": "python3"
   },
@@ -459,7 +399,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
COS is not necessary for this notebook on WS since we already can download the model into our Python Kernel.